### PR TITLE
Convert email to lower case for Gravatar hashing

### DIFF
--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -536,7 +536,8 @@ public final class ScooldUtils {
 	}
 
 	public String getGravatar(String email) {
-		return "https://www.gravatar.com/avatar/" + Utils.md5(email) + "?size=400&d=retro";
+		if(email == null) return "https://www.gravatar.com/avatar?d=retro&size=400";
+		return "https://www.gravatar.com/avatar/" + Utils.md5(email.toLowerCase()) + "?size=400&d=retro";
 	}
 
 	public String getGravatar(Profile profile) {


### PR DESCRIPTION
Gravatar stores emails in lower case while scoold does not.
`MD5("first.last@email.com")` is not the same as `MD5("First.Last@email.com")`. A simple fix is to convert email to lower case before hashing it.