### PR TITLE
Disable RedirectHttp10Compatible of VelocityViewResolver to stay on https

### DIFF
--- a/src/main/java/com/erudika/scoold/ScooldServer.java
+++ b/src/main/java/com/erudika/scoold/ScooldServer.java
@@ -192,12 +192,6 @@ public class ScooldServer extends SpringBootServletInitializer {
 			public void addInterceptors(InterceptorRegistry registry) {
 				registry.addInterceptor(sri);
 			}
-
-			public void configureViewResolvers(ViewResolverRegistry registry) {
-				VelocityViewResolver viewr = new VelocityViewResolver();
-				viewr.setSuffix(".vm");
-				registry.viewResolver(viewr);
-			}
 		};
 	}
 
@@ -322,5 +316,14 @@ public class ScooldServer extends SpringBootServletInitializer {
 				epr.addErrorPages(new ErrorPage(Exception.class, "/error/500"));
 			}
 		};
+	}
+	
+	@Bean
+	public ViewResolver viewResolver() {
+		VelocityViewResolver viewr = new VelocityViewResolver();
+		viewr.setRedirectHttp10Compatible(false);
+		viewr.setSuffix(".vm");
+		viewr.setOrder(Ordered.HIGHEST_PRECEDENCE);
+		return viewr;
 	}
 }


### PR DESCRIPTION
Move VelocityViewResolver out of WebMvcConfigurer in order to give VelocityViewResolver a higher order. 

If not, the implicit MustacheViewResolver will be used before VelocityViewResolver during the redirect flow (return "redirect:/ ...") which will redirect back to Http even if Scoold is hosted on Https. And a redirect during a POST call will fail (Such like delete your question).