### PR TITLE
Fix request URL for globals.js when using CDN

### DIFF
--- a/src/main/resources/templates/base.vm
+++ b/src/main/resources/templates/base.vm
@@ -40,7 +40,7 @@
 		#if($!langDirection == "RTL")
 		<link href="$!styleslink/rtl.css" rel="stylesheet">
 		#end
-		<script nonce="$cspNonce" src="$!scriptslink/globals.js"></script>
+		<script nonce="$cspNonce" src="$!request.contextPath/scripts/globals.js"></script>
 		#if ($includeGMapsScripts && $includeGMapsScripts == true)
 		<script nonce="$cspNonce" type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=places&key=$!GMAPS_API_KEY"></script>
 		#end


### PR DESCRIPTION
When serving static files from a CDN, the request to /scripts/globals.js is made to CDN, and it's not processed by SigninController#globals.