### PR TITLE
Translate all mails

### DIFF
--- a/src/main/java/com/erudika/scoold/controllers/CommentController.java
+++ b/src/main/java/com/erudika/scoold/controllers/CommentController.java
@@ -127,7 +127,7 @@ public class CommentController {
 					if (parentPost != null && parentPost.addCommentId(showComment.getId())) {
 						pc.update(parentPost); // update without adding revisions
 					}
-					utils.sendCommentNotification(parentPost, showComment, authUser);
+					utils.sendCommentNotification(parentPost, showComment, authUser, req);
 				}
 			}
 		}

--- a/src/main/java/com/erudika/scoold/controllers/QuestionController.java
+++ b/src/main/java/com/erudika/scoold/controllers/QuestionController.java
@@ -233,7 +233,7 @@ public class QuestionController {
 				model.addAttribute("showPost", showPost);
 				model.addAttribute("answerslist", Collections.singletonList(answer));
 				// send email to the question author
-				utils.sendReplyNotifications(showPost, answer);
+				utils.sendReplyNotifications(showPost, answer, req);
 				model.addAttribute("newpost", getNewAnswerPayload(answer));
 			} else {
 				model.addAttribute("error", error);

--- a/src/main/java/com/erudika/scoold/controllers/QuestionController.java
+++ b/src/main/java/com/erudika/scoold/controllers/QuestionController.java
@@ -260,7 +260,7 @@ public class QuestionController {
 			if (showPost instanceof UnapprovedQuestion) {
 				showPost.setType(Utils.type(Question.class));
 				pc.create(showPost);
-				utils.sendNewPostNotifications(showPost);
+				utils.sendNewPostNotifications(showPost, req);
 			} else if (showPost instanceof UnapprovedReply) {
 				showPost.setType(Utils.type(Reply.class));
 				pc.create(showPost);

--- a/src/main/java/com/erudika/scoold/controllers/QuestionController.java
+++ b/src/main/java/com/erudika/scoold/controllers/QuestionController.java
@@ -178,7 +178,7 @@ public class QuestionController {
 			updatePost(showPost, authUser);
 			updateLocation(showPost, authUser, location, latlng);
 			utils.addBadgeOnceAndUpdate(authUser, Badge.EDITOR, true);
-			utils.sendUpdatedFavTagsNotifications(showPost, new ArrayList<>(addedTags));
+			utils.sendUpdatedFavTagsNotifications(showPost, new ArrayList<>(addedTags), req);
 		}
 		model.addAttribute("post", showPost);
 		if (utils.isAjaxRequest(req)) {

--- a/src/main/java/com/erudika/scoold/controllers/QuestionsController.java
+++ b/src/main/java/com/erudika/scoold/controllers/QuestionsController.java
@@ -212,7 +212,7 @@ public class QuestionsController {
 				q.setLocation(location);
 				q.setAuthor(authUser);
 				String qid = q.create();
-				utils.sendNewPostNotifications(q);
+				utils.sendNewPostNotifications(q, req);
 				if (!StringUtils.isBlank(latlng)) {
 					Address addr = new Address(qid + Config.SEPARATOR + Utils.type(Address.class));
 					addr.setAddress(address);

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -702,7 +702,7 @@ public final class ScooldUtils {
 		return value
 				.replaceAll("'", "%27")
 				.replaceAll("\"", "%22")
-				.replaceAll("\\/", "");
+				.replaceAll("\\\\", "");
 	}
 
 	private String escapeHtml(String value) {

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -646,7 +646,9 @@ public final class ScooldUtils {
 			String subject = Utils.formatMessage(lang.get("notification.reply.subject"), name, Utils.abbreviate(reply.getTitle(), 255));
 			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage(lang.get("notification.reply.heading"), Utils.formatMessage("<a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle()))));
+			model.put("heading", Utils.formatMessage(
+					lang.get("notification.reply.heading"),
+					Utils.formatMessage("<a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle()))));
 			model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div>{2}</div>", picture, escapeHtml(name), body));
 
 			Profile authorProfile = pc.read(parentPost.getCreatorid());
@@ -702,7 +704,9 @@ public final class ScooldUtils {
 				String subject = Utils.formatMessage(lang.get("notification.comment.subject"), name, parentPost.getTitle());
 				model.put("subject", escapeHtml(subject));
 				model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-				model.put("heading", Utils.formatMessage(lang.get("notification.comment.heading"), Utils.formatMessage("<a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle()))));
+				model.put("heading", Utils.formatMessage(
+						lang.get("notification.comment.heading"),
+						Utils.formatMessage("<a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle()))));
 				model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div class='panel'>{2}</div>", pic, escapeHtml(name), body));
 				emailer.sendEmail(Arrays.asList(((User) author).getEmail()), subject, compileEmailTemplate(model));
 

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -563,11 +563,12 @@ public final class ScooldUtils {
 	}
 
 	@SuppressWarnings("unchecked")
-	public void sendUpdatedFavTagsNotifications(Post question, List<String> addedTags) {
+	public void sendUpdatedFavTagsNotifications(Post question, List<String> addedTags, HttpServletRequest req) {
 		// sends a notification to subscibers of a tag if that tag was added to an existing question
 		if (question != null && !question.isReply() && addedTags != null && !addedTags.isEmpty()) {
 			Profile postAuthor = question.getAuthor(); // the current user - same as utils.getAuthUser(req)
 			Map<String, Object> model = new HashMap<String, Object>();
+			Map<String, String> lang = getLang(req);
 			String name = postAuthor.getName();
 			String body = Utils.markdownToHtml(question.getBody());
 			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(postAuthor.getPicture()));
@@ -575,12 +576,11 @@ public final class ScooldUtils {
 			String tagsString = Optional.ofNullable(question.getTags()).orElse(Collections.emptyList()).stream().
 					map(t -> "<span class=\"tag\">" + (addedTags.contains(t) ? "<b>" + escapeHtml(t) + "<b>" : escapeHtml(t)) + "</span>").
 					collect(Collectors.joining("&nbsp;"));
-			String subject = name + " edited question '" + Utils.abbreviate(question.getTitle(), 255) + "'";
+			String subject = Utils.formatMessage(lang.get("notification.favtags.subject"), name, Utils.abbreviate(question.getTitle(), 255));
 			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage("{0} {1} edited:", picture, escapeHtml(name)));
-			model.put("body", Utils.formatMessage(
-					"<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
+			model.put("heading", Utils.formatMessage(lang.get("notification.favtags.heading"), picture, escapeHtml(name)));
+			model.put("body", Utils.formatMessage("<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
 					postURL, escapeHtml(question.getTitle()), body, tagsString));
 
 			Set<String> emails = getFavTagsSubscribers(addedTags);

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -591,7 +591,7 @@ public final class ScooldUtils {
 	}
 
 	@SuppressWarnings("unchecked")
-	public void sendNewPostNotifications(Post question) {
+	public void sendNewPostNotifications(Post question, HttpServletRequest req) {
 		if (question == null) {
 			return;
 		}
@@ -599,6 +599,7 @@ public final class ScooldUtils {
 		Profile postAuthor = question.getAuthor() != null ? question.getAuthor() : pc.read(question.getCreatorid());
 		if (!question.getType().equals(Utils.type(UnapprovedQuestion.class))) {
 			Map<String, Object> model = new HashMap<String, Object>();
+			Map<String, String> lang = getLang(req);
 			String name = postAuthor.getName();
 			String body = Utils.markdownToHtml(question.getBody());
 			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(postAuthor.getPicture()));
@@ -606,10 +607,10 @@ public final class ScooldUtils {
 			String tagsString = Optional.ofNullable(question.getTags()).orElse(Collections.emptyList()).stream().
 					map(t -> "<span class=\"tag\">" + escapeHtml(t) + "</span>").
 					collect(Collectors.joining("&nbsp;"));
-			String subject = name + " posted the question '" + Utils.abbreviate(question.getTitle(), 255) + "'";
+			String subject = Utils.formatMessage(lang.get("notification.newposts.subject"), name, Utils.abbreviate(question.getTitle(), 255));
 			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage("{0} {1} posted:", picture, escapeHtml(name)));
+			model.put("heading", Utils.formatMessage(lang.get("notification.newposts.heading"), picture, escapeHtml(name)));
 			model.put("body", Utils.formatMessage(
 					"<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
 					postURL, escapeHtml(question.getTitle()), body, tagsString));

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -359,7 +359,7 @@ public final class ScooldUtils {
 			String body1 = Utils.formatMessage(Config.getConfigParam("emails.welcome_text1",
 					lang.get("signin.welcome.body1") + "<br><br>"), Config.APP_NAME);
 			String body2 = Config.getConfigParam("emails.welcome_text2", lang.get("signin.welcome.body2") + "<br><br>");
-			String body3 = Utils.formatMessage(Config.getConfigParam("emails.welcome_text3", "Best, <br>The {0} team<br><br>"),
+			String body3 = Utils.formatMessage(Config.getConfigParam("emails.welcome_text3", lang.get("signin.welcome.body3") + "<br><br>"),
 					Config.APP_NAME);
 
 			if (verifyEmail && !user.getActive() && !StringUtils.isBlank(user.getIdentifier())) {
@@ -386,7 +386,7 @@ public final class ScooldUtils {
 			Map<String, Object> model = new HashMap<String, Object>();
 			Map<String, String> lang = getLang(req);
 			String subject = Utils.formatMessage(lang.get("signin.welcome"), Config.APP_NAME);
-			String body = Utils.formatMessage(Config.getConfigParam("emails.welcome_text3", "Best, <br>The {0} team<br><br>"),
+			String body = Utils.formatMessage(Config.getConfigParam("emails.welcome_text3", lang.get("signin.welcome.body3") + "<br><br>"),
 					Config.APP_NAME);
 
 			Sysprop s = pc.read(email);

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -373,6 +373,7 @@ public final class ScooldUtils {
 				}
 			}
 
+			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 			model.put("heading", Utils.formatMessage(lang.get("signin.welcome.title"), escapeHtml(user.getName())));
 			model.put("body", body1 + body2 + body3);
@@ -397,6 +398,7 @@ public final class ScooldUtils {
 				body = "<b><a href=\"" + token + "\">" + lang.get("signin.welcome.verify") + "</a></b><br><br>" + body;
 			}
 
+			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 			model.put("heading", lang.get("hello"));
 			model.put("body", body);
@@ -414,6 +416,7 @@ public final class ScooldUtils {
 			String body2 = Utils.formatMessage("<b><a href=\"{0}\">RESET PASSWORD</a></b><br><br>", url);
 			String body3 = "Best, <br>The " + Config.APP_NAME + " team<br><br>";
 
+			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 			model.put("heading", lang.get("hello"));
 			model.put("body", body1 + body2 + body3);
@@ -572,6 +575,8 @@ public final class ScooldUtils {
 			String tagsString = Optional.ofNullable(question.getTags()).orElse(Collections.emptyList()).stream().
 					map(t -> "<span class=\"tag\">" + (addedTags.contains(t) ? "<b>" + escapeHtml(t) + "<b>" : escapeHtml(t)) + "</span>").
 					collect(Collectors.joining("&nbsp;"));
+			String subject = name + " edited question '" + Utils.abbreviate(question.getTitle(), 255) + "'";
+			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 			model.put("heading", Utils.formatMessage("{0} {1} edited:", picture, escapeHtml(name)));
 			model.put("body", Utils.formatMessage(
@@ -580,7 +585,7 @@ public final class ScooldUtils {
 
 			Set<String> emails = getFavTagsSubscribers(addedTags);
 			sendEmailsToSubscribersInSpace(emails, question.getSpace(),
-					name + " edited question '" + Utils.abbreviate(question.getTitle(), 255) + "'",
+					subject,
 					compileEmailTemplate(model));
 		}
 	}
@@ -601,6 +606,8 @@ public final class ScooldUtils {
 			String tagsString = Optional.ofNullable(question.getTags()).orElse(Collections.emptyList()).stream().
 					map(t -> "<span class=\"tag\">" + escapeHtml(t) + "</span>").
 					collect(Collectors.joining("&nbsp;"));
+			String subject = name + " posted the question '" + Utils.abbreviate(question.getTitle(), 255) + "'";
+			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 			model.put("heading", Utils.formatMessage("{0} {1} posted:", picture, escapeHtml(name)));
 			model.put("body", Utils.formatMessage(
@@ -610,7 +617,7 @@ public final class ScooldUtils {
 			Set<String> emails = new HashSet<String>(getNotificationSubscribers(EMAIL_ALERTS_PREFIX + "new_post_subscribers"));
 			emails.addAll(getFavTagsSubscribers(question.getTags()));
 			sendEmailsToSubscribersInSpace(emails, question.getSpace(),
-					name + " posted the question '" + Utils.abbreviate(question.getTitle(), 255) + "'",
+					subject,
 					compileEmailTemplate(model));
 		} else if (postsNeedApproval() && question instanceof UnapprovedQuestion) {
 			Report rep = new Report();
@@ -631,6 +638,8 @@ public final class ScooldUtils {
 			String body = Utils.markdownToHtml(reply.getBody());
 			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(replyAuthor.getPicture()));
 			String postURL = getServerURL() + parentPost.getPostLink(false, false);
+			String subject = name + " replied to '" + Utils.abbreviate(reply.getTitle(), 255) + "'";
+			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 			model.put("heading", Utils.formatMessage("New reply to <a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle())));
 			model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div>{2}</div>", picture, escapeHtml(name), body));
@@ -656,7 +665,7 @@ public final class ScooldUtils {
 
 			if (parentPost.hasFollowers()) {
 				emailer.sendEmail(new ArrayList<String>(parentPost.getFollowers().values()),
-						name + " replied to '" + Utils.abbreviate(reply.getTitle(), 255) + "'",
+						subject,
 						compileEmailTemplate(model));
 			}
 		}
@@ -684,11 +693,12 @@ public final class ScooldUtils {
 				String body = Utils.markdownToHtml(comment.getComment());
 				String pic = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(commentAuthor.getPicture()));
 				String postURL = getServerURL() + parentPost.getPostLink(false, false);
+				String subject = name + " commented on '" + parentPost.getTitle() + "'";
+				model.put("subject", escapeHtml(subject));
 				model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
 				model.put("heading", Utils.formatMessage("New comment on <a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle())));
 				model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div class='panel'>{2}</div>", pic, escapeHtml(name), body));
-				emailer.sendEmail(Arrays.asList(((User) author).getEmail()), name + " commented on '" +
-						parentPost.getTitle() + "'", compileEmailTemplate(model));
+				emailer.sendEmail(Arrays.asList(((User) author).getEmail()), subject, compileEmailTemplate(model));
 
 				Map<String, Object> payload = new LinkedHashMap<>(ParaObjectUtils.getAnnotatedFields(comment, false));
 				payload.put("parent", parentPost);

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -359,8 +359,7 @@ public final class ScooldUtils {
 			String body1 = Utils.formatMessage(Config.getConfigParam("emails.welcome_text1",
 					lang.get("signin.welcome.body1") + "<br><br>"), Config.APP_NAME);
 			String body2 = Config.getConfigParam("emails.welcome_text2", lang.get("signin.welcome.body2") + "<br><br>");
-			String body3 = Utils.formatMessage(Config.getConfigParam("emails.welcome_text3", lang.get("signin.welcome.body3") + "<br><br>"),
-					Config.APP_NAME);
+			String body3 = getMailDefaultSignature(Config.getConfigParam("emails.welcome_text3", lang.get("signin.welcome.body3") + "<br><br>"));
 
 			if (verifyEmail && !user.getActive() && !StringUtils.isBlank(user.getIdentifier())) {
 				Sysprop s = pc.read(user.getIdentifier());
@@ -381,13 +380,17 @@ public final class ScooldUtils {
 		}
 	}
 
+	private String getMailDefaultSignature(String defaultText) {
+		String template = Config.getConfigParam("emails.default_signature", defaultText);
+		return Utils.formatMessage(template, Config.APP_NAME);
+	}
+
 	public void sendVerificationEmail(String email, HttpServletRequest req) {
 		if (!StringUtils.isBlank(email)) {
 			Map<String, Object> model = new HashMap<String, Object>();
 			Map<String, String> lang = getLang(req);
 			String subject = Utils.formatMessage(lang.get("signin.welcome"), Config.APP_NAME);
-			String body = Utils.formatMessage(Config.getConfigParam("emails.welcome_text3", lang.get("signin.welcome.body3") + "<br><br>"),
-					Config.APP_NAME);
+			String body = getMailDefaultSignature(Config.getConfigParam("emails.welcome_text3", lang.get("signin.welcome.body3") + "<br><br>"));
 
 			Sysprop s = pc.read(email);
 			if (s != null) {
@@ -414,7 +417,7 @@ public final class ScooldUtils {
 			String subject = lang.get("iforgot.title");
 			String body1 = lang.get("iforgot.body1") + "<br><br>";
 			String body2 = Utils.formatMessage("<b><a href=\"{0}\">" + lang.get("iforgot.body2") + "</a></b><br><br>", url);
-			String body3 = Utils.formatMessage(lang.get("iforgot.body3") + "<br><br>", Config.APP_NAME);
+			String body3 = getMailDefaultSignature(lang.get("iforgot.body3") + "<br><br>");
 
 			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -95,6 +95,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.RegExUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
@@ -373,7 +374,7 @@ public final class ScooldUtils {
 			}
 
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage(lang.get("signin.welcome.title"), user.getName()));
+			model.put("heading", Utils.formatMessage(lang.get("signin.welcome.title"), escapeHtml(user.getName())));
 			model.put("body", body1 + body2 + body3);
 			emailer.sendEmail(Arrays.asList(user.getEmail()), subject, compileEmailTemplate(model));
 		}
@@ -566,15 +567,16 @@ public final class ScooldUtils {
 			Map<String, Object> model = new HashMap<String, Object>();
 			String name = postAuthor.getName();
 			String body = Utils.markdownToHtml(question.getBody());
-			String picture = Utils.formatMessage("<img src='{0}' width='25'>", postAuthor.getPicture());
+			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(postAuthor.getPicture()));
 			String postURL = getServerURL() + question.getPostLink(false, false);
 			String tagsString = Optional.ofNullable(question.getTags()).orElse(Collections.emptyList()).stream().
-					map(t -> "<span class=\"tag\">" + (addedTags.contains(t) ? "<b>" + t + "<b>" : t) + "</span>").
+					map(t -> "<span class=\"tag\">" + (addedTags.contains(t) ? "<b>" + escapeHtml(t) + "<b>" : escapeHtml(t)) + "</span>").
 					collect(Collectors.joining("&nbsp;"));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage("{0} {1} edited:", picture, name));
-			model.put("body", Utils.formatMessage("<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
-					postURL, question.getTitle(), body, tagsString));
+			model.put("heading", Utils.formatMessage("{0} {1} edited:", picture, escapeHtml(name)));
+			model.put("body", Utils.formatMessage(
+					"<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
+					postURL, escapeHtml(question.getTitle()), body, tagsString));
 
 			Set<String> emails = getFavTagsSubscribers(addedTags);
 			sendEmailsToSubscribersInSpace(emails, question.getSpace(),
@@ -594,15 +596,16 @@ public final class ScooldUtils {
 			Map<String, Object> model = new HashMap<String, Object>();
 			String name = postAuthor.getName();
 			String body = Utils.markdownToHtml(question.getBody());
-			String picture = Utils.formatMessage("<img src='{0}' width='25'>", postAuthor.getPicture());
+			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(postAuthor.getPicture()));
 			String postURL = getServerURL() + question.getPostLink(false, false);
 			String tagsString = Optional.ofNullable(question.getTags()).orElse(Collections.emptyList()).stream().
-					map(t -> "<span class=\"tag\">" + t + "</span>").
+					map(t -> "<span class=\"tag\">" + escapeHtml(t) + "</span>").
 					collect(Collectors.joining("&nbsp;"));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage("{0} {1} posted:", picture, name));
-			model.put("body", Utils.formatMessage("<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
-					postURL, question.getTitle(), body, tagsString));
+			model.put("heading", Utils.formatMessage("{0} {1} posted:", picture, escapeHtml(name)));
+			model.put("body", Utils.formatMessage(
+					"<h2><a href='{0}'>{1}</a></h2><div>{2}</div><br>{3}",
+					postURL, escapeHtml(question.getTitle()), body, tagsString));
 
 			Set<String> emails = new HashSet<String>(getNotificationSubscribers(EMAIL_ALERTS_PREFIX + "new_post_subscribers"));
 			emails.addAll(getFavTagsSubscribers(question.getTags()));
@@ -626,11 +629,11 @@ public final class ScooldUtils {
 			Map<String, Object> model = new HashMap<String, Object>();
 			String name = replyAuthor.getName();
 			String body = Utils.markdownToHtml(reply.getBody());
-			String picture = Utils.formatMessage("<img src='{0}' width='25'>", replyAuthor.getPicture());
+			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(replyAuthor.getPicture()));
 			String postURL = getServerURL() + parentPost.getPostLink(false, false);
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage("New reply to <a href='{0}'>{1}</a>", postURL, parentPost.getTitle()));
-			model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div>{2}</div>", picture, name, body));
+			model.put("heading", Utils.formatMessage("New reply to <a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle())));
+			model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div>{2}</div>", picture, escapeHtml(name), body));
 
 			Profile authorProfile = pc.read(parentPost.getCreatorid());
 			if (authorProfile != null) {
@@ -679,11 +682,11 @@ public final class ScooldUtils {
 				Map<String, Object> model = new HashMap<String, Object>();
 				String name = commentAuthor.getName();
 				String body = Utils.markdownToHtml(comment.getComment());
-				String pic = Utils.formatMessage("<img src='{0}' width='25'>", commentAuthor.getPicture());
+				String pic = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(commentAuthor.getPicture()));
 				String postURL = getServerURL() + parentPost.getPostLink(false, false);
 				model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-				model.put("heading", Utils.formatMessage("New comment on <a href='{0}'>{1}</a>", postURL, parentPost.getTitle()));
-				model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div class='panel'>{2}</div>", pic, name, body));
+				model.put("heading", Utils.formatMessage("New comment on <a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle())));
+				model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div class='panel'>{2}</div>", pic, escapeHtml(name), body));
 				emailer.sendEmail(Arrays.asList(((User) author).getEmail()), name + " commented on '" +
 						parentPost.getTitle() + "'", compileEmailTemplate(model));
 
@@ -693,6 +696,17 @@ public final class ScooldUtils {
 				triggerHookEvent("comment.create", payload);
 			});
 		}
+	}
+
+	private String escapeHtmlAttribute(String value) {
+		return value
+				.replaceAll("'", "%27")
+				.replaceAll("\"", "%22")
+				.replaceAll("\\/", "");
+	}
+
+	private String escapeHtml(String value) {
+		return StringEscapeUtils.escapeHtml4(value);
 	}
 
 	public Profile readAuthUser(HttpServletRequest req) {

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -412,9 +412,9 @@ public final class ScooldUtils {
 			Map<String, String> lang = getLang(req);
 			String url = getServerURL() + CONTEXT_PATH + SIGNINLINK + "/iforgot?email=" + email + "&token=" + token;
 			String subject = lang.get("iforgot.title");
-			String body1 = "Open the link below to change your password:<br><br>";
-			String body2 = Utils.formatMessage("<b><a href=\"{0}\">RESET PASSWORD</a></b><br><br>", url);
-			String body3 = "Best, <br>The " + Config.APP_NAME + " team<br><br>";
+			String body1 = lang.get("iforgot.body1") + "<br><br>";
+			String body2 = Utils.formatMessage("<b><a href=\"{0}\">" + lang.get("iforgot.body2") + "</a></b><br><br>", url);
+			String body3 = Utils.formatMessage(lang.get("iforgot.body3") + "<br><br>", Config.APP_NAME);
 
 			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -629,19 +629,20 @@ public final class ScooldUtils {
 		}
 	}
 
-	public void sendReplyNotifications(Post parentPost, Post reply) {
+	public void sendReplyNotifications(Post parentPost, Post reply, HttpServletRequest req) {
 		// send email notification to author of post except when the reply is by the same person
 		if (parentPost != null && reply != null && !StringUtils.equals(parentPost.getCreatorid(), reply.getCreatorid())) {
 			Profile replyAuthor = reply.getAuthor(); // the current user - same as utils.getAuthUser(req)
 			Map<String, Object> model = new HashMap<String, Object>();
+			Map<String, String> lang = getLang(req);
 			String name = replyAuthor.getName();
 			String body = Utils.markdownToHtml(reply.getBody());
 			String picture = Utils.formatMessage("<img src='{0}' width='25'>", escapeHtmlAttribute(replyAuthor.getPicture()));
 			String postURL = getServerURL() + parentPost.getPostLink(false, false);
-			String subject = name + " replied to '" + Utils.abbreviate(reply.getTitle(), 255) + "'";
+			String subject = Utils.formatMessage(lang.get("notification.reply.subject"), name, Utils.abbreviate(reply.getTitle(), 255));
 			model.put("subject", escapeHtml(subject));
 			model.put("logourl", Config.getConfigParam("small_logo_url", "https://scoold.com/logo.png"));
-			model.put("heading", Utils.formatMessage("New reply to <a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle())));
+			model.put("heading", Utils.formatMessage(lang.get("notification.reply.heading"), Utils.formatMessage("<a href='{0}'>{1}</a>", postURL, escapeHtml(parentPost.getTitle()))));
 			model.put("body", Utils.formatMessage("<h2>{0} {1}:</h2><div>{2}</div>", picture, escapeHtml(name), body));
 
 			Profile authorProfile = pc.read(parentPost.getCreatorid());

--- a/src/main/resources/lang_en.properties
+++ b/src/main/resources/lang_en.properties
@@ -200,6 +200,7 @@ signin.welcome = Welcome to {0}!
 signin.welcome.title = Hello {0},
 signin.welcome.body1 = You are now part of {0} - a friendly Q&A community where you can get answers to your questions.
 signin.welcome.body2 = To get started, simply navigate to the "Ask question" page and ask a question. You can also help people by answering their questions and you will get reputation points.
+signin.welcome.body3 = Best, <br>The {0} team
 signin.welcome.verify = Verify your email here!
 signin.verify.text = Done! Check your email and follow the link to verify it.
 signin.verify.done = Email verified!

--- a/src/main/resources/lang_en.properties
+++ b/src/main/resources/lang_en.properties
@@ -38,6 +38,8 @@ notification.reply.subject = {0} replied to '{1}'
 notification.reply.heading = New reply to {0}
 notification.comment.subject = {0} commented on '{1}'
 notification.comment.heading = New comment on {0}
+notification.favtags.subject = {0} edited question '{1}'
+notification.favtags.heading = {0} {1} edited:
 
 voteup.tooltip = Vote up
 votedown.tooltip = Vote down

--- a/src/main/resources/lang_en.properties
+++ b/src/main/resources/lang_en.properties
@@ -40,6 +40,8 @@ notification.comment.subject = {0} commented on '{1}'
 notification.comment.heading = New comment on {0}
 notification.favtags.subject = {0} edited question '{1}'
 notification.favtags.heading = {0} {1} edited:
+notification.newposts.subject = {0} posted the question '{1}'
+notification.newposts.heading = {0} {1} posted:
 
 voteup.tooltip = Vote up
 votedown.tooltip = Vote down

--- a/src/main/resources/lang_en.properties
+++ b/src/main/resources/lang_en.properties
@@ -29,6 +29,9 @@ voterep.title = Voting and Reputation
 administration.title = Administration
 spaces.title = Spaces
 iforgot.title = Forgotten password
+iforgot.body1 = Open the link below to change your password:
+iforgot.body2 = RESET PASSWORD
+iforgot.body3 = Best, <br>The {0} team
 backups.title = Backup and Restore
 
 voteup.tooltip = Vote up

--- a/src/main/resources/lang_en.properties
+++ b/src/main/resources/lang_en.properties
@@ -34,6 +34,9 @@ iforgot.body2 = RESET PASSWORD
 iforgot.body3 = Best, <br>The {0} team
 backups.title = Backup and Restore
 
+notification.reply.subject = {0} replied to '{1}'
+notification.reply.heading = New reply to {0}
+
 voteup.tooltip = Vote up
 votedown.tooltip = Vote down
 

--- a/src/main/resources/lang_en.properties
+++ b/src/main/resources/lang_en.properties
@@ -36,6 +36,8 @@ backups.title = Backup and Restore
 
 notification.reply.subject = {0} replied to '{1}'
 notification.reply.heading = New reply to {0}
+notification.comment.subject = {0} commented on '{1}'
+notification.comment.heading = New comment on {0}
 
 voteup.tooltip = Vote up
 votedown.tooltip = Vote down

--- a/src/main/resources/lang_fr.properties
+++ b/src/main/resources/lang_fr.properties
@@ -29,7 +29,19 @@ voterep.title = Vote et r\u00e9putation
 administration.title = Administration
 spaces.title = Espaces
 iforgot.title = Mot de passe oubli\u00e9
+iforgot.body1 = Ouvrez le lien ci-dessous pour changer votre mot de passe :
+iforgot.body2 = R\u00c9INITIALISER LE MOT DE PASSE
+iforgot.body3 = A bient\u00f4t, <br>L'\u00e9quipe {0}
 backups.title = Sauvegarde et Restauration
+
+notification.reply.subject = {0} a r\u00e9pondu \u00e0 '{1}'
+notification.reply.heading = Nouvelle r\u00e9ponse \u00e0 {0}
+notification.comment.subject = {0} a comment\u00e9 sur '{1}'
+notification.comment.heading = Nouveau commentaire sur {0}
+notification.favtags.subject = {0} a \u00e9dit\u00e9 la question '{1}'
+notification.favtags.heading = {0} {1} a \u00e9dit\u00e9 :
+notification.newposts.subject = {0} a publi\u00e9 la question '{1}'
+notification.newposts.heading = {0} {1} a publi\u00e9 :
 
 voteup.tooltip = Vote positif
 votedown.tooltip = Vote n\u00e9gatif
@@ -200,6 +212,7 @@ signin.welcome = Bienvenue sur {0}!
 signin.welcome.title = Bonjour {0},
 signin.welcome.body1 = Vous faites maintenant partie de {0} - une communaut\u00e9 Q & R conviviale o\u00f9 vous pouvez obtenir des r\u00e9ponses \u00e0 vos questions.
 signin.welcome.body2 = Pour commencer, acc\u00e9dez simplement \u00e0 la page "Poser une question" et posez une question. Vous pouvez \u00e9galement aider les gens en r\u00e9pondant \u00e0 leurs questions et vous obtiendrez des points de r\u00e9putation.
+signin.welcome.body3 = A bient\u00f4t, <br>L'\u00e9quipe {0}
 signin.welcome.verify = V\u00e9rifier votre email ici!
 signin.verify.text = Termin\u00e9! V\u00e9rifier votre bo\u00eete email et suivez le lien pour le v\u00e9rifier.
 signin.verify.done = Email v\u00e9rifi\u00e9!


### PR DESCRIPTION
Hello,

Only welcome mail is translate.  
In PR, I have translate other mails.  
I have translate only for FR, but it does not impact other languages because it will remain in English for them.

I also added:
- `subject` variable in mail template. It's equals to mail subject.
- `para.emails.default_signature` config. If it's not empty (not break change), then override mail signature (welcome and lost password).

This PR depend of https://github.com/Erudika/scoold/pull/269