### PR TITLE
Allow to disable notifications

### DIFF
--- a/src/main/java/com/erudika/scoold/controllers/SettingsController.java
+++ b/src/main/java/com/erudika/scoold/controllers/SettingsController.java
@@ -88,18 +88,18 @@ public class SettingsController {
 			}
 			setAnonymity(authUser, req.getParameter("anon"));
 			setDarkMode(authUser, req.getParameter("dark"));
-			if(utils.isReplyNotificationAllowed()) {
+			if (utils.isReplyNotificationAllowed()) {
 				authUser.setReplyEmailsEnabled(Boolean.valueOf(replyEmailsOn));
 			}
-			if(utils.isCommentNotificationAllowed()) {
+			if (utils.isCommentNotificationAllowed()) {
 				authUser.setCommentEmailsEnabled(Boolean.valueOf(commentEmailsOn));
 			}
-			if(utils.isFavTagsNotificationAllowed()) {
+			if (utils.isFavTagsNotificationAllowed()) {
 				authUser.setFavtagsEmailsEnabled(Boolean.valueOf(favtagsEmailsOn));
 			}
 			authUser.update();
 
-			if(utils.isNewPostNotificationAllowed()) {
+			if (utils.isNewPostNotificationAllowed()) {
 				if (Boolean.valueOf(newpostEmailsOn)) {
 					utils.subscribeToNewPosts(authUser.getUser());
 				} else {

--- a/src/main/java/com/erudika/scoold/controllers/SettingsController.java
+++ b/src/main/java/com/erudika/scoold/controllers/SettingsController.java
@@ -64,6 +64,11 @@ public class SettingsController {
 		model.addAttribute("path", "settings.vm");
 		model.addAttribute("title", utils.getLang(req).get("settings.title"));
 		model.addAttribute("newpostEmailsEnabled", utils.isSubscribedToNewPosts(req));
+		model.addAttribute("emailsAllowed", utils.isNotificationsAllowed());
+		model.addAttribute("newpostEmailsAllowed", utils.isNewPostNotificationAllowed());
+		model.addAttribute("favtagsEmailsAllowed", utils.isFavTagsNotificationAllowed());
+		model.addAttribute("replyEmailsAllowed", utils.isReplyNotificationAllowed());
+		model.addAttribute("commentEmailsAllowed", utils.isCommentNotificationAllowed());
 		model.addAttribute("includeGMapsScripts", utils.isNearMeFeatureEnabled());
 		return "base";
 	}

--- a/src/main/java/com/erudika/scoold/controllers/SettingsController.java
+++ b/src/main/java/com/erudika/scoold/controllers/SettingsController.java
@@ -88,15 +88,23 @@ public class SettingsController {
 			}
 			setAnonymity(authUser, req.getParameter("anon"));
 			setDarkMode(authUser, req.getParameter("dark"));
-			authUser.setReplyEmailsEnabled(Boolean.valueOf(replyEmailsOn));
-			authUser.setCommentEmailsEnabled(Boolean.valueOf(commentEmailsOn));
-			authUser.setFavtagsEmailsEnabled(Boolean.valueOf(favtagsEmailsOn));
+			if(utils.isReplyNotificationAllowed()) {
+				authUser.setReplyEmailsEnabled(Boolean.valueOf(replyEmailsOn));
+			}
+			if(utils.isCommentNotificationAllowed()) {
+				authUser.setCommentEmailsEnabled(Boolean.valueOf(commentEmailsOn));
+			}
+			if(utils.isFavTagsNotificationAllowed()) {
+				authUser.setFavtagsEmailsEnabled(Boolean.valueOf(favtagsEmailsOn));
+			}
 			authUser.update();
 
-			if (Boolean.valueOf(newpostEmailsOn)) {
-				utils.subscribeToNewPosts(authUser.getUser());
-			} else {
-				utils.unsubscribeFromNewPosts(authUser.getUser());
+			if(utils.isNewPostNotificationAllowed()) {
+				if (Boolean.valueOf(newpostEmailsOn)) {
+					utils.subscribeToNewPosts(authUser.getUser());
+				} else {
+					utils.unsubscribeFromNewPosts(authUser.getUser());
+				}
 			}
 
 			if (resetPasswordAndUpdate(authUser.getUser(), oldpassword, newpassword)) {

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -740,6 +740,26 @@ public final class ScooldUtils {
 		return Config.getConfigBoolean("footer_links_enabled", true);
 	}
 
+	public boolean isNotificationsAllowed() {
+		return Config.getConfigBoolean("notification_emails_allowed", true);
+	}
+
+	public boolean isNewPostNotificationAllowed() {
+		return isNotificationsAllowed() && Config.getConfigBoolean("newpost_emails_allowed", true);
+	}
+
+	public boolean isFavTagsNotificationAllowed() {
+		return isNotificationsAllowed() && Config.getConfigBoolean("favtags_emails_allowed", true);
+	}
+
+	public boolean isReplyNotificationAllowed() {
+		return isNotificationsAllowed() && Config.getConfigBoolean("reply_emails_allowed", true);
+	}
+
+	public boolean isCommentNotificationAllowed() {
+		return isNotificationsAllowed() && Config.getConfigBoolean("comment_emails_allowed", true);
+	}
+
 	public boolean isDarkModeEnabled() {
 		return Config.getConfigBoolean("dark_mode_enabled", true);
 	}

--- a/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
+++ b/src/main/java/com/erudika/scoold/utils/ScooldUtils.java
@@ -478,7 +478,9 @@ public final class ScooldUtils {
 	}
 
 	public Object isSubscribedToNewPosts(HttpServletRequest req) {
-		if(!isNewPostNotificationAllowed()) return false;
+		if (!isNewPostNotificationAllowed()) {
+			return false;
+		}
 
 		Profile authUser = getAuthUser(req);
 		if (authUser != null) {
@@ -562,7 +564,9 @@ public final class ScooldUtils {
 
 	@SuppressWarnings("unchecked")
 	public void sendUpdatedFavTagsNotifications(Post question, List<String> addedTags) {
-		if(!isFavTagsNotificationAllowed()) return;
+		if (!isFavTagsNotificationAllowed()) {
+			return;
+		}
 
 		// sends a notification to subscibers of a tag if that tag was added to an existing question
 		if (question != null && !question.isReply() && addedTags != null && !addedTags.isEmpty()) {
@@ -595,7 +599,9 @@ public final class ScooldUtils {
 		// the current user - same as utils.getAuthUser(req)
 		Profile postAuthor = question.getAuthor() != null ? question.getAuthor() : pc.read(question.getCreatorid());
 		if (!question.getType().equals(Utils.type(UnapprovedQuestion.class))) {
-			if(!isNewPostNotificationAllowed()) return;
+			if (!isNewPostNotificationAllowed()) {
+				return;
+			}
 
 			Map<String, Object> model = new HashMap<String, Object>();
 			String name = postAuthor.getName();
@@ -682,7 +688,7 @@ public final class ScooldUtils {
 			List<Profile> last5commentators = pc.readAll(new ArrayList<>(last5ids));
 			last5commentators = last5commentators.stream().filter(u -> u.getCommentEmailsEnabled()).collect(Collectors.toList());
 			pc.readAll(last5commentators.stream().map(u -> u.getCreatorid()).collect(Collectors.toList())).forEach(author -> {
-				if(isCommentNotificationAllowed()) {
+				if (isCommentNotificationAllowed()) {
 					Map<String, Object> model = new HashMap<String, Object>();
 					String name = commentAuthor.getName();
 					String body = Utils.markdownToHtml(comment.getComment());

--- a/src/main/resources/templates/settings.vm
+++ b/src/main/resources/templates/settings.vm
@@ -75,8 +75,10 @@
 				</div>
 			#end
 
+			#if($emailsAllowed)
 			<h4 class="ptl">$!lang.get('settings.notifications')</h4>
 			<p class="mvl grey-text text-darken-1"><i class="fa fa-envelope"></i> <tt>$!authUser.user.email</tt></p>
+			#if($newpostEmailsAllowed)
 			<div class="mbm">
 				<div class="switch">
 					<label>
@@ -127,6 +129,8 @@
 
 				</div>
 			</div>
+			#end
+			#if($favtagsEmailsAllowed)
 			<div class="mbm">
 				<div class="switch">
 					<label>
@@ -142,6 +146,8 @@
 					<span class="mll mediumText">$!lang.get('settings.favtagsemails')</span>
 				</div>
 			</div>
+			#end
+			#if($replyEmailsAllowed)
 			<div class="mbm">
 				<div class="switch">
 					<label>
@@ -157,6 +163,8 @@
 					<span class="mll mediumText">$!lang.get('settings.replyemails')</span>
 				</div>
 			</div>
+			#end
+			#if($commentEmailsAllowed)
 			<div class="mbl">
 				<div class="switch">
 					<label>
@@ -172,6 +180,8 @@
 					<span class="mll mediumText">$!lang.get('settings.commentemails')</span>
 				</div>
 			</div>
+			#end
+			#end
 
 			#if($scooldUtils.isDarkModeEnabled())
 			<h4 class="ptl">$!lang.get('settings.darkmode')</h4>


### PR DESCRIPTION
Hello,

In my case, sending an email for each new question is too important.  
I would like to disable these notifications too greedy.  
So I added some config keys to disable some notifications:
- `para.notification_emails_allowed`: disable all notifications
- `para.newpost_emails_allowed`: disable notifications for new posts
- `para.favtags_emails_allowed`: disable notifications for new posts that match favorite tags
- `para.reply_emails_allowed`: disable notifications for replies
- `para.comment_emails_allowed`: disable notifications for comments
