### PR TITLE
Fix js error on any page other than Profile

### DIFF
--- a/src/main/resources/templates/base.vm
+++ b/src/main/resources/templates/base.vm
@@ -409,7 +409,7 @@
 		#set($isAdminJS = "IS_ADMIN = $isAdmin")
 		#set($maxTagsJS = "MAX_TAGS_PER_POST = $MAX_TAGS_PER_POST")
 		#set($minPassLen = "MIN_PASS_LENGTH = $MIN_PASS_LENGTH")
-		#set($avatarUploadsEnabledBool = $scooldUtils.isAvatarUploadsEnabled() && $authenticated)
+		#set($avatarUploadsEnabledBool = $scooldUtils.isAvatarUploadsEnabled() && $authenticated && $request.getServletPath() == $profilelink)
 		#set($avatarUploadsEnabledJS = "AVATAR_UPLOADS_ENABLED = $avatarUploadsEnabledBool")
 		#set($_welcomeMsg = $scooldUtils.getWelcomeMessage($authUser))
 		#set($_welcomeMessageJS = "WELCOME_MESSAGE = '$_welcomeMsg'")


### PR DESCRIPTION
inlineAttachment dependencies isn't load on any page other than Profile.  
But if avatarUploadsEnabledBool is true, then scoold.js try to initialize upload.

This PR disable avatarUploadsEnabledBool to avoid error on any page other than Profile.  

**PR Checklist**

- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document.
- [X] I checked to ensure there aren't other open [Pull Requests](https://github.com/Erudika/scoold/pulls) or issues on the same topic?
- [X] I have updated the documentation accordingly (if necessary at all).
- [X] My code follows the code style of this project and **does not** alter whitespace formatting.
- [X] My pull request **does not** introduce features which are already implemented in Scoold Pro.

*Large PRs with changes to more than 20 files are strongly discouraged but will be reviewed.*