### PR TITLE
Allow moderator to approve answer

### DIFF
--- a/src/main/java/com/erudika/scoold/controllers/QuestionController.java
+++ b/src/main/java/com/erudika/scoold/controllers/QuestionController.java
@@ -280,7 +280,7 @@ public class QuestionController {
 			return "redirect:" + req.getRequestURI();
 		}
 		if (utils.canEdit(showPost, authUser) && answerid != null &&
-				(utils.isMine(showPost, authUser) || utils.isAdmin(authUser))) {
+				(utils.isMine(showPost, authUser) || utils.isMod(authUser))) {
 			Reply answer = (Reply) pc.read(answerid);
 
 			if (answer != null && answer.isReply()) {

--- a/src/main/resources/templates/macro.vm
+++ b/src/main/resources/templates/macro.vm
@@ -703,7 +703,7 @@
 				<div class="left mtm mrl approve-answer-btn">
 					#set($approvedAnswer = $showpost.id.equals($parentpost.answerid))
 					#if ($approvedAnswer)	#set($onclass = "green-text text-lighten-1") #else #set($onclass = "") #end
-					#if ($authenticated && $showpost.isReply() && ($parentpost.creatorid.equals($authUser.id) || $isAdmin))
+					#if ($authenticated && $showpost.isReply() && ($parentpost.creatorid.equals($authUser.id) || $isMod))
 						<a href="$questionlink/$!parentpost.id/approve/$!showpost.id" class="approve-answer $!{onclass}"
 							 title="Approve answer"><i class="fa fa-check-circle fa-3x"></i></a>
 					#elseif ($approvedAnswer)


### PR DESCRIPTION
This is a proposed change.  
Currently, the moderator cannot approve a answer. But sometimes the user is not used to this system and forgets to approve a answer.  
Currently, only an administrator can do this.
It seems to me interesting to let also the moderator.


**PR Checklist**

- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document.
- [X] I checked to ensure there aren't other open [Pull Requests](https://github.com/Erudika/scoold/pulls) or issues on the same topic?
- [X] I have updated the documentation accordingly (if necessary at all).
- [X] My code follows the code style of this project and **does not** alter whitespace formatting.
- [X] My pull request **does not** introduce features which are already implemented in Scoold Pro.

*Large PRs with changes to more than 20 files are strongly discouraged but will be reviewed.*