### PR TITLE
Fix accent url

### DIFF
--- a/src/main/java/com/erudika/scoold/core/Post.java
+++ b/src/main/java/com/erudika/scoold/core/Post.java
@@ -538,8 +538,8 @@ public abstract class Post extends Sysprop {
 
 	public String getPostLink(boolean plural, boolean noid, boolean withContextPathPrefix) {
 		Post p = this;
-		String ptitle = Utils.noSpaces(Utils.stripAndTrim(p.getTitle()), "-");
-		String pid = (noid ? "" : "/" + p.getId() + "/" + ptitle);
+		String ptitle = StringUtils.stripAccents(Utils.noSpaces(Utils.stripAndTrim(p.getTitle()), "-"));
+		String pid = (noid ? "" : "/" + Utils.urlEncode(p.getId()) + "/" + Utils.urlEncode(ptitle));
 		String ctx = withContextPathPrefix ? CONF.serverContextPath() : "";
 		if (p.isQuestion()) {
 			return ctx + (plural ? ScooldServer.QUESTIONSLINK : ScooldServer.QUESTIONLINK + pid);

--- a/src/main/java/com/erudika/scoold/core/Profile.java
+++ b/src/main/java/com/erudika/scoold/core/Profile.java
@@ -22,6 +22,7 @@ import com.erudika.para.core.User;
 import com.erudika.para.core.annotations.Stored;
 import com.erudika.para.core.utils.Para;
 import com.erudika.para.core.utils.Utils;
+import com.erudika.scoold.ScooldServer;
 import com.erudika.scoold.utils.ScooldUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.Instant;
@@ -750,6 +751,13 @@ public class Profile extends Sysprop {
 					Collections.singletonMap("properties.closed", false)).intValue();
 		}
 		return newreports;
+	}
+
+	public String getProfileLink() {
+		String name = StringUtils.stripAccents(Utils.noSpaces(Utils.stripAndTrim(this.getName()), "-"));
+		String seoName = StringUtils.isBlank(name) ? "" : ("/" + name);
+		String pid = "/" + Utils.urlEncode(this.getCreatorid()) + seoName;
+		return ScooldServer.PROFILELINK + pid;
 	}
 
 	public boolean equals(Object obj) {

--- a/src/main/resources/templates/macro.vm
+++ b/src/main/resources/templates/macro.vm
@@ -348,7 +348,7 @@
 <div class="row mbn userbox user-${userboxid}">
 	<div class="col s4 m5 l3">
 		#if ($showu)
-			<a href="$profilelink/$!showu.creatorid/#stripstr($!showu.name)" title="$!showu.name">
+			<a href="$!showu.getProfileLink()" title="$!showu.name">
 				<img src="#profilepic($!showu, 'Square50')" width="50" class="profile-pic responsive-img" alt="pic">
 			</a>
 		#else
@@ -368,7 +368,7 @@
 		</div>
 		<div class="userbox-body">
 			#if ($showu)
-				<a href="$profilelink/$!showu.creatorid/#stripstr($!showu.name)" class="userbox-name">$showu.name</a>
+				<a href="$!showu.getProfileLink()" class="userbox-name">$showu.name</a>
 			#else
 				<span class="grey-text">$!lang.get("profile.deleted")</span>
 			#end
@@ -396,7 +396,7 @@
 #macro(tinypersonbox $showu)
 <div>
 	#if ($showu)
-		<a href="$profilelink/$!showu.creatorid/#stripstr($!showu.name)" title="$!showu.name [$!showu.votes]">
+		<a href="$!showu.getProfileLink()" title="$!showu.name [$!showu.votes]">
 			<img src="#profilepic($!showu, 'Square32')" width="32" class="profile-pic responsive-img" alt="pic">
 		</a>
 	#else
@@ -408,8 +408,7 @@
 #macro(personlink $showu)
 <span>
 	#if ($showu)
-		#if ($showu.name)#set($seopsuffix = "/#stripstr($!showu.name)" )#else#set($seopsuffix = "" )#end
-		<a href="$profilelink/$!{showu.id}$!{seosuffix}" title="Go to profile">$!showu.name</a>
+		<a href="$!showu.getProfileLink()" title="Go to profile">$!showu.name</a>
 	#else
 		$!lang.get("profile.deleted")
 	#end
@@ -444,7 +443,7 @@
 		<div class="card personbox ${personboxClass} #if($scooldUtils.isBanned($showFriend) && $isMod)yellow lighten-5 #end">
 			<div class="row ${cardClass}">
 				<div class="col ${cardCol1Class}" title="$!showFriend.name">
-					<a href="$profilelink/$!showFriend.creatorid/#stripstr($!showFriend.name)" title="$!showFriend.name">
+					<a href="$!showFriend.getProfileLink()" title="$!showFriend.name">
 						<img src="#profilepic($showFriend, 'Square127')" class="profile-pic responsive-img" alt="pic">
 					</a>
 				</div>
@@ -466,12 +465,12 @@
 								<label for="$!showFriend.id">
 									<input type="checkbox" name="selectedUsers" value="$!showFriend.id" class="filled-in" id="$!showFriend.id">
 									<span>
-										<a href="$profilelink/${showFriend.creatorid}/#stripstr($!showFriend.name)">$!{showFriend.name}</a>
+										<a href="$!showFriend.getProfileLink()">$!{showFriend.name}</a>
 									</span>
 								</label>
 							</span>
 						#else
-							<a href="$profilelink/${showFriend.creatorid}/#stripstr($!showFriend.name)">$!{showFriend.name}</a>
+							<a href="$!showFriend.getProfileLink()">$!{showFriend.name}</a>
 						#end
 					</div>
 					#if($isAdmin && $request.getParameter("bulkedit") && !$hideSpacesForMods)
@@ -550,7 +549,7 @@
 #macro(questionspage $posts )
 	#set($showSpaceLabel = $scooldUtils.isAllSpaces($currentSpace) || $isMod)
 	#foreach($showpost in $posts)
-	#set($actionlink = "#getpostlink($showpost false true)")
+	#set($actionlink = "#getpostlink($showpost false false)")
 	#set($actionlink2 = "#getpostlink($showpost true true)")
 	#if($showpost.id == $request.getParameter("deleted"))
 		#set($deleted = "hide")
@@ -624,7 +623,7 @@
 						#if($showpost.type == "unapprovedquestion")
 						<i class="fa fa-exclamation-circle grey-text tooltipped" data-tooltip="$!lang.get('posts.unapproved')"></i>
 						#end
-						<a href="$!actionlink/$!utils.urlEncode($showpost.id)/#stripstr($!showpost.title)" class="mediumText">
+						<a href="$!actionlink" class="mediumText">
 							#if($showSpaceLabel)
 								#set($spaceLabel = "$!scooldUtils.getSpaceName($!showpost.space)")
 								#if(!$spaceLabel.trim().isEmpty())
@@ -687,7 +686,7 @@
 							#if($showpost.type == "unapprovedquestion")
 								<i class="fa fa-exclamation-circle grey-text tooltipped" data-tooltip="$!lang.get('posts.unapproved')"></i>
 							#end
-							<a href="$!actionlink/$!utils.urlEncode($showpost.id)/#stripstr($!showpost.title)" class="mediumText">$!showpost.title</a>
+							<a href="$!actionlink" class="mediumText">$!showpost.title</a>
 						</div>
 						<div class="mbs">
 							#set($showBody = $utils.stripHtml($utils.markdownToHtml($utils.stripHtml($!showpost.body))) )

--- a/src/main/resources/templates/question.vm
+++ b/src/main/resources/templates/question.vm
@@ -23,7 +23,7 @@
 			</span>
 			<div id="post-title" class="largeText">
 				#if($showPost.isReply())
-					<a href="$questionlink/$showPost.parentid/#stripstr($!showPost.title)" class="tooltipped" data-tooltip="⮪ $!lang.get('backtopost')">
+					<a href="$!showPost.getPostLinkForRedirect()" class="tooltipped" data-tooltip="⮪ $!lang.get('backtopost')">
 						<i class="fa fa-reply smallText grey-text"></i> $!{showPost.title}
 					</a>
 				#else
@@ -50,9 +50,9 @@
 					#set($sortarr = {'votes': "", 'newest': ""} )
 					#setsortbyselection($sortarr 'votes')
 					<span class="right">
-						<a href="$questionlink/$showPost.id/#stripstr($showPost.title)#sortorderparam('?')" title="Most voted answers"
+						<a href="$!showPost.getPostLinkForRedirect()#sortorderparam('?')" title="Most voted answers"
 							 class="chip $sortarr.votes">#sortordericon() $!lang.get("votes")</a>
-						<a href="$questionlink/$showPost.id/#stripstr($showPost.title)?sortby=newest#sortorderparam('&' 'newest')" title="Newest answers"
+						<a href="$!showPost.getPostLinkForRedirect()?sortby=newest#sortorderparam('&' 'newest')" title="Newest answers"
 							 class="chip $sortarr.newest">#sortordericon("newest") $!lang.get("newest")</a>
 					</span>
 					<h3 class="grey-text">$!lang.get("answers.title") #showcount($itemcount.count)</h3>


### PR DESCRIPTION
This fixes a bug and improves urls for SEO.  

Currently, if a question has accents in the title, then there are `%` in the url.
This creates a technical error when an unauthenticated user tries to answer this question.
When he clicks on answer, it asks him to identify himself, then redirects him to the question, but displays an “HTTP Status 400 - Bad Request” error.

I also did the same thing for the profile.

**PR Checklist**

- [X] I have read the **[CONTRIBUTING](../CONTRIBUTING.md)** document.
- [X] I checked to ensure there aren't other open [Pull Requests](https://github.com/Erudika/scoold/pulls) or issues on the same topic?
- [X] I have updated the documentation accordingly (if necessary at all).
- [X] My code follows the code style of this project and **does not** alter whitespace formatting.
- [X] My pull request **does not** introduce features which are already implemented in Scoold Pro.

*Large PRs with changes to more than 20 files are strongly discouraged but will be reviewed.*