### PR TITLE
Add tests for avatar repository and generator classes

### DIFF
--- a/src/test/java/com/erudika/scoold/utils/avatars/CloudinaryAvatarRepositoryTest.java
+++ b/src/test/java/com/erudika/scoold/utils/avatars/CloudinaryAvatarRepositoryTest.java
@@ -101,4 +101,26 @@ public class CloudinaryAvatarRepositoryTest {
 		assertNotEquals(avatar, profile.getPicture());
 		assertNotEquals(avatar, profile.getUser().getPicture());
 	}
+
+	@Test
+	public void getLink_should_return_original_link_for_non_cloudinary_url_with_upload_path() {
+		profile.setPicture("https://example.com/upload/avatar.jpg");
+
+		String avatar = repository.getLink(profile, AvatarFormat.Profile);
+
+		assertEquals("https://example.com/upload/avatar.jpg", avatar);
+	}
+
+	@Test
+	public void store_should_return_true_when_next_repository_stores_non_cloudinary_url() {
+		AvatarRepository defaultRepository = mock(AvatarRepository.class);
+		AvatarRepository repository = new CloudinaryAvatarRepository(defaultRepository);
+		String avatar = "https://avatar";
+		when(defaultRepository.store(profile, avatar)).thenReturn(true);
+
+		boolean result = repository.store(profile, avatar);
+
+		verify(defaultRepository).store(profile, avatar);
+		assertTrue(result);
+	}
 }

--- a/src/test/java/com/erudika/scoold/utils/avatars/GravatarAvatarGeneratorTest.java
+++ b/src/test/java/com/erudika/scoold/utils/avatars/GravatarAvatarGeneratorTest.java
@@ -22,6 +22,7 @@ import com.erudika.scoold.core.Profile;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public class GravatarAvatarGeneratorTest {
 	private GravatarAvatarGenerator generator;
@@ -101,6 +102,35 @@ public class GravatarAvatarGeneratorTest {
 	public void isLink_should_be_true_if_gravatar_domain() {
 		assertTrue(generator.isLink("https://www.gravatar.com/avatar/1ac9dec7bfff4aeb9bc9e625bfb9a4ce?s=50&r=g&d=identicon"));
 		assertFalse(generator.isLink("https://avatar.com"));
+	}
+
+	@Test
+	public void getRawLink_should_produce_same_hash_for_uppercase_email() {
+		String urlLower = generator.getRawLink("toto@example.com");
+		String urlUpper = generator.getRawLink("TOTO@EXAMPLE.COM");
+
+		assertEquals(urlLower, urlUpper);
+	}
+
+	@Test
+	public void configureLink_should_use_ampersand_when_url_already_ends_with_question_mark() {
+		String rawLink = generator.getRawLink("toto@example.com");
+		String urlWithQuestion = rawLink + "?";
+
+		String configured = generator.configureLink(urlWithQuestion, AvatarFormat.Square32);
+
+		assertTrue(configured.contains("&s=32"));
+		assertFalse(configured.contains("??s=32"));
+	}
+
+	@Test
+	public void getRawLink_should_return_empty_url_when_profile_has_no_user() {
+		Profile profile = Mockito.mock(Profile.class);
+		Mockito.when(profile.getUser()).thenReturn(null);
+
+		String url = generator.getRawLink(profile);
+
+		assertEquals(generator.getRawLink(""), url);
 	}
 
 	private Profile getProfileWithEmail(String email) {

--- a/src/test/java/com/erudika/scoold/utils/avatars/GravatarAvatarRepositoryTest.java
+++ b/src/test/java/com/erudika/scoold/utils/avatars/GravatarAvatarRepositoryTest.java
@@ -66,6 +66,19 @@ public class GravatarAvatarRepositoryTest {
 	}
 
 	@Test
+	public void getLink_should_delegate_to_next_if_picture_is_not_gravatar() {
+		AvatarRepository nextRepo = mock(AvatarRepository.class);
+		GravatarAvatarRepository repo = new GravatarAvatarRepository(gravatarGenerator, nextRepo);
+		profile.setPicture("https://example.com/avatar.png");
+		when(nextRepo.getLink(profile, AvatarFormat.Square32)).thenReturn("https://example.com/avatar.png");
+
+		String avatar = repo.getLink(profile, AvatarFormat.Square32);
+
+		assertEquals("https://example.com/avatar.png", avatar);
+		verify(nextRepo, times(1)).getLink(profile, AvatarFormat.Square32);
+	}
+
+	@Test
 	public void getLink_should_configure_link_if_picture_is_a_gravatar() {
 		profile.getUser().setEmail("toto@example.com");
 		profile.setPicture(gravatarGenerator.getRawLink("titi@example.com"));

--- a/src/test/java/com/erudika/scoold/utils/avatars/ImgurAvatarRepositoryTest.java
+++ b/src/test/java/com/erudika/scoold/utils/avatars/ImgurAvatarRepositoryTest.java
@@ -104,4 +104,75 @@ public class ImgurAvatarRepositoryTest {
 		assertNotEquals(avatar, profile.getOriginalPicture());
 	}
 
+	@Test
+	public void getLink_should_return_picture_for_valid_imgur_link() {
+		String imgurUrl = "https://i.imgur.com/abc123.png";
+		profile.setPicture(imgurUrl);
+
+		String avatar = repository.getLink(profile, AvatarFormat.Profile);
+
+		assertEquals(imgurUrl, avatar);
+	}
+
+	@Test
+	public void getLink_should_return_picture_for_valid_imgur_i_link() {
+		String imgurUrl = "https://i.imgur.com/xyz789.jpg";
+		profile.setPicture(imgurUrl);
+
+		String avatar = repository.getLink(profile, AvatarFormat.Profile);
+
+		assertEquals(imgurUrl, avatar);
+	}
+
+	@Test
+	public void getLink_should_call_next_repository_when_profile_is_null() {
+		AvatarRepository nextRepo = mock(AvatarRepository.class);
+		when(nextRepo.getLink(null, AvatarFormat.Profile)).thenReturn("https://default");
+		AvatarRepository repository = new ImgurAvatarRepository(nextRepo);
+
+		String avatar = repository.getLink(null, AvatarFormat.Profile);
+
+		verify(nextRepo).getLink(null, AvatarFormat.Profile);
+		assertEquals("https://default", avatar);
+	}
+
+	@Test
+	public void getLink_should_call_next_repository_when_picture_is_blank() {
+		AvatarRepository nextRepo = mock(AvatarRepository.class);
+		when(nextRepo.getLink(profile, AvatarFormat.Profile)).thenReturn("https://default");
+		AvatarRepository repository = new ImgurAvatarRepository(nextRepo);
+		profile.setPicture("");
+
+		String avatar = repository.getLink(profile, AvatarFormat.Profile);
+
+		verify(nextRepo).getLink(profile, AvatarFormat.Profile);
+		assertEquals("https://default", avatar);
+	}
+
+	@Test
+	public void store_should_return_true_for_non_imgur_url_when_next_repository_succeeds() {
+		AvatarRepository nextRepo = mock(AvatarRepository.class);
+		AvatarRepository repository = new ImgurAvatarRepository(nextRepo);
+		String url = "https://example.com/avatar.png";
+		when(nextRepo.store(profile, url)).thenReturn(true);
+
+		boolean result = repository.store(profile, url);
+
+		verify(nextRepo).store(profile, url);
+		assertEquals(true, result);
+	}
+
+	@Test
+	public void store_should_call_next_repository_for_non_imgur_url() {
+		AvatarRepository nextRepo = mock(AvatarRepository.class);
+		AvatarRepository repository = new ImgurAvatarRepository(nextRepo);
+		String url = "https://example.com/avatar.png";
+		when(nextRepo.store(profile, url)).thenReturn(false);
+
+		boolean result = repository.store(profile, url);
+
+		verify(nextRepo).store(profile, url);
+		assertEquals(false, result);
+	}
+
 }


### PR DESCRIPTION
This adds unit tests for the avatar repository and generator classes in com.erudika.scoold.utils.avatars, using only the public API. No production code is changed.

- CloudinaryAvatarRepository: avatar URL resolution and configuration handling.
- GravatarAvatarGenerator and GravatarAvatarRepository: Gravatar URL construction, size parameter, and defaults.
- ImgurAvatarRepository: Imgur avatar URL handling.

All four test classes pass: mvn test on JDK 21.